### PR TITLE
Make error id generation configurable

### DIFF
--- a/lib/straw_hat/error/error.ex
+++ b/lib/straw_hat/error/error.ex
@@ -64,6 +64,12 @@ defmodule StrawHat.Error do
       |> Keyword.get(:metadata, [])
       |> ErrorMetadata.serialize()
 
-    %__MODULE__{id: UUID.uuid1(), code: code, type: type, metadata: metadata}
+    id = Keyword.get_lazy(opts, :id, default_id_generator())
+
+    %__MODULE__{id: id, code: code, type: type, metadata: metadata}
+  end
+
+  defp default_id_generator() do
+    Application.get_env(:straw_hat, :id_generator, &Uniq.UUID.uuid1/0)
   end
 end

--- a/lib/straw_hat/error/error.ex
+++ b/lib/straw_hat/error/error.ex
@@ -64,12 +64,12 @@ defmodule StrawHat.Error do
       |> Keyword.get(:metadata, [])
       |> ErrorMetadata.serialize()
 
-    id = Keyword.get_lazy(opts, :id, default_id_generator())
+    id = Keyword.get_lazy(opts, :id, generate_id)
 
     %__MODULE__{id: id, code: code, type: type, metadata: metadata}
   end
 
-  defp default_id_generator() do
+  defp generate_id do
     Application.get_env(:straw_hat, :id_generator, &Uniq.UUID.uuid1/0)
   end
 end


### PR DESCRIPTION
### Description

 * Make the id generator for `StrawHat.Error` configurable.
 * Allow the id to be passed to `StrawHat.Error.new` to avoid generating a new id.

### Motivation and Context

I noticed a bug in the uniq library, https://github.com/bitwalker/uniq/pull/22. My first thought was to pass the id as a parameter, second to replace the id generator function. Sadly I had to go upstream twice to get around this bug. This fix allows for more flexibility when the default assumptions don't hold as well.

### Types of changes

- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x ] New feature (a non-breaking change which adds functionality)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature
  but make things better)

*Does it introduce breaking changes?*

- [ ] Breaking change (fix or feature that would cause existing functionality to
  not work as expected)

### Checklist

<!--- Go over all the following points, and fill up with an `x` in all the
boxes that apply. -->

- [ x] Check other PRs and make sure that the changes are not done yet.
- [ x] The PR title is no longer than 64 characters.
- [ x] Keep the title short and descriptive, as it will be used as a commit
      message